### PR TITLE
Add topic command

### DIFF
--- a/birch
+++ b/birch
@@ -188,6 +188,10 @@ cmd() {
             send "NAMES $chan"
         ;;
 
+        '/topic'*)
+            send "TOPIC $chan"
+        ;;
+
         /*) 
             send "NOTICE :${1/ *} not implemented yet" 
         ;;


### PR DESCRIPTION
`/topic` will print the current channel's topic.

Example usage:
`/topic` -->
```
 -- #kisslinux
         -- KISS - https://k1ss.org - logs: 
            https://freenode.logbot.info/kisslinux/ - song of the day: 
            https://youtu.be/mwircEDCss8
```

Theoretically it could also be possible to print [another channel's topic](https://tools.ietf.org/html/rfc1459#section-4.2.4), as evident by:  
`/raw TOPIC #unjoinedchannel`  
which in this case will join the channel and print the topic, but not sure if that is wanted, and if so, how to best combine a simple `/topic` and `/topic #channel` in this [switch case](https://github.com/dylanaraps/birch/blob/master/birch#L143). I would just leave it out.