### PR TITLE
modified notify-send call to trigger when messaged privately

### DIFF
--- a/birch
+++ b/birch
@@ -285,7 +285,7 @@ parse() {
         PRIVMSG)
             prin "$pu ${mesg//$nick/$me}"
 
-            [[ $mesg == *$nick* ]] &&
+            [[ $dest == *$nick* || $mesg == *$nick* ]] &&
                 type -p notify-send >/dev/null &&
                 notify-send "birch: New mention" "$whom: $mesg"
         ;;


### PR DESCRIPTION
Compares private message destination to nick and triggers notify-send if the destination is a private message, placed in same conditional as the mentioned nick.