### PR TITLE
Away command

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Other:
 /nick <nick>          - Change nickname.
 /names                - Display all nicks in channel.
 /topic                - Display channel topic.
+/away <message>       - Set afk message.
 /raw <args>           - Send a raw IRC message.
 ```
 

--- a/birch
+++ b/birch
@@ -213,6 +213,14 @@ cmd() {
             send "TOPIC $chan"
         ;;
 
+        '/away '*)
+            send "AWAY :$a $args"
+        ;;
+
+        '/away'*)
+            send "AWAY"
+        ;;
+
         /*)
             send "NOTICE :${1/ *} not implemented yet"
         ;;
@@ -330,6 +338,11 @@ parse() {
 
         PING)
             printf 'PONG%s\n' "${1##PING}" >&9
+        ;;
+
+        AWAY)
+            dest=$nick
+            prin "-- Away status: $mesg"
         ;;
 
         00?|2[56]?|37?)


### PR DESCRIPTION
```
/away I am afk. brb.
-- Away status: I am afk. brb.
-- You have been marked as being away
```
Now if a user private messages you, they get the away message as a response.
To unset your away status, issue `/away` without an argument.

Further description here: [RFC 1459](https://tools.ietf.org/html/rfc1459#section-5.1)